### PR TITLE
fix: Allow proxy to all ports

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -142,6 +142,7 @@ http {
         set $docker_proxy_request_type "unknown-connect";
 
         proxy_connect;
+        proxy_connect_allow all;
         proxy_connect_address $interceptedHost;
         proxy_max_temp_file_size 0;
 


### PR DESCRIPTION
This allows the proxy to connect to all ports (not just 443, and 563). Fixes the situation in which a node is attempting to connect to a docker repository that lives on a non standard port. Currently, the proxy will 403 the request right after the proxy CONNECT.