### PR TITLE
Allow curl to follow redirects

### DIFF
--- a/liveliness.sh
+++ b/liveliness.sh
@@ -7,7 +7,7 @@ read -r -a repos <<< "$LIVELINESS_REPOS"
 for i in "${repos[@]}"
 do
   echo "repo $i liveliness check..."
-  response=$(curl --head -w '%{http_code}' -o /dev/null -s -k -x http://127.0.0.1:3128 "$i")
+  response=$(curl --head -L -w '%{http_code}' -o /dev/null -s -k -x http://127.0.0.1:3128 "$i")
   if [ "$response" -ne 200 ]; then
     echo "failed curl for repo $i"
     exit 1


### PR DESCRIPTION
This intended to allow the liveliness script to follow redirects for its probes. We had to redeploy regproxy today because google decided to do a redirect.

```
(⎈ |tenant:regproxy)➜  ~ k exec -it regproxy-67886dd897-jtbmm bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
bash-5.0# curl https://cloud.google.com/container-registry/
<!doctype html>
<html lang=en>
<title>Redirecting...</title>
<h1>Redirecting...</h1>
<p>You should be redirected automatically to the target URL: <a href="/artifact-registry">/artifact-registry</a>. If not, click the link.
```

Related to https://github.com/coreweave/k8s-services/pull/2602