### PR TITLE
fix(nginx): handle relative redirect

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -296,7 +296,10 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             # the proxy_* directives, these will disappear
             set $original_uri $uri;
             set $orig_loc $upstream_http_location;
-
+            # Handle relative re-direct in Location header (as opposed to absolute)
+            if ($upstream_http_location !~* "http") {
+                set $orig_loc "${scheme}://${host}${upstream_http_location}";
+            }
             # during this process, nginx will preserve the headers intended for the original destination.
             # in most cases thats okay, but for some (eg: google storage), passing an Authorization
             # header can cause problems. Also, that would leak the credentials for the registry

--- a/nginx.conf
+++ b/nginx.conf
@@ -297,7 +297,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             set $original_uri $uri;
             set $orig_loc $upstream_http_location;
             # Handle relative re-direct in Location header (as opposed to absolute)
-            if ($upstream_http_location !~* "http") {
+            if ($upstream_http_location !~ "^http") {
                 set $orig_loc "${scheme}://${host}${upstream_http_location}";
             }
             # during this process, nginx will preserve the headers intended for the original destination.


### PR DESCRIPTION
Some GCP container registries return `302` with a _relative_ redirect header; not absolute:

```
2023/09/11 17:32:25 <-- 302 https://us-docker.pkg.dev/v2/cloudrun/container/hello/blobs/sha256:de18b6f62ee469a691de1a2de8ba495d81ce157cb5e3e2a6172a0cc759fc075f (108.953271ms)
2023/09/11 17:32:25 HTTP/2.0 302 Found
Content-Length: 757
Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
Content-Type: text/html; charset=utf-8
Date: Mon, 11 Sep 2023 17:32:25 GMT
Docker-Distribution-Api-Version: registry/2.0
Location: /artifacts-downloads/namespaces/cloudrun/repositories/container/downloads/AK-MDKQA3lMPhanyePw6CovsxLN4RkQMy2a3q6mia_M71GpudQ6i4TX8eiEv554pk2Lg1AWL0Ay6tdMpL_T1FU9qDJNvk-qL0LxdJQLifaBQgNMPwAfi5Df4mJlUUbQ5DnuG3XQlgziuEBOhU2vF9RvR3CNm30wmoQNIOGKtghLeqsdkJe7SGeC70WE0YF_h6NocRxzq19DmRcc1FpkrHzgpR-4gW6dFaJR2HCKJpxCBQy0BQALPWcQHrvGAL7dnSOFK6tVsNz0CM8N2jKmr6ipBQOv7EQBvbvyj9KXgU2BczTFz6MekQjgf-pcIuHmTJyJVplOcxWeNieCaPnidW6ZbKhGJvUVPHGATeyxsGaalGHTZEzPgFYZ7RjK5U09oDvikTVTlvRYaHw2YFD3DH86SUB60nerJayUu_Ve29G9y3XPJnuXg_LQXZ9cnLujBscEQm4fJJm0gm_WkwYY6FWxD9B6fs4pWqw7E44kI1r_kSndKfKeVy7UNBuY9xOptLk16xe0b_iH-8xbGIX7djeSE8NewgKMIilSmJP8dnT_3ueQZpwxacleqAMgHiHY5PUxJeojkic1bHyYL1eyTJjEmQBee00w27TqQS4bRpk1zMCYPnAqNoTJ3zzy8132rbo5dao5yw6wl41Tqxg==
X-Content-Type-Options: nosniff
X-Frame-Options: SAMEORIGIN
X-Xss-Protection: 0

<a href="/artifacts-downloads/namespaces/cloudrun/repositories/container/downloads/AK-MDKQA3lMPhanyePw6CovsxLN4RkQMy2a3q6mia_M71GpudQ6i4TX8eiEv554pk2Lg1AWL0Ay6tdMpL_T1FU9qDJNvk-qL0LxdJQLifaBQgNMPwAfi5Df4mJlUUbQ5DnuG3XQlgziuEBOhU2vF9RvR3CNm30wmoQNIOGKtghLeqsdkJe7SGeC70WE0YF_h6NocRxzq19DmRcc1FpkrHzgpR-4gW6dFaJR2HCKJpxCBQy0BQALPWcQHrvGAL7dnSOFK6tVsNz0CM8N2jKmr6ipBQOv7EQBvbvyj9KXgU2BczTFz6MekQjgf-pcIuHmTJyJVplOcxWeNieCaPnidW6ZbKhGJvUVPHGATeyxsGaalGHTZEzPgFYZ7RjK5U09oDvikTVTlvRYaHw2YFD3DH86SUB60nerJayUu_Ve29G9y3XPJnuXg_LQXZ9cnLujBscEQm4fJJm0gm_WkwYY6FWxD9B6fs4pWqw7E44kI1r_kSndKfKeVy7UNBuY9xOptLk16xe0b_iH-8xbGIX7djeSE8NewgKMIilSmJP8dnT_3ueQZpwxacleqAMgHiHY5PUxJeojkic1bHyYL1eyTJjEmQBee00w27TqQS4bRpk1zMCYPnAqNoTJ3zzy8132rbo5dao5yw6wl41Tqxg==">Found</a>.
```

This confuses the `@handle_redirects` directive which passes the value of the `Location` header to `proxy_pass`

https://github.com/coreweave/docker-registry-proxy/blob/27414bbb3285d3cfd619088f3aba7fcc60dbb010/nginx.conf#L293-L298

https://github.com/coreweave/docker-registry-proxy/blob/27414bbb3285d3cfd619088f3aba7fcc60dbb010/nginx.conf#L306-L307

This leaves nginx with no `scheme` (or top level domain) 

```
2023/09/11 19:11:31 [error] 106#106: *40 invalid URL prefix in "/artifacts-downloads/namespaces/cloudrun/repositories/container/downloads/AK-MDKSgv6JEVDECgfQewMthIvNzSf30ilVjZoulkQooYsPazhODmfyvIGL_sHxtwP4muBcmyZjH_XhAnySJpsoRUa48f6krEduAa1NsYcAHh4WxlEnw5UevS9RGQpIa2yBxR8FSTJjXUgTY0Acmq1PK92wH_31FVVRuRAvoP4T1KwKOP4DkRrtKqBNIWfK866MaubnV3PvEVt1z4KV3HpRBMC8e19eLpsluF7g_sDqAX64npgoXJVKUNGuMjVZipFmGgU1dxxeT0gG4s9pmo_iRywmMM69Lh7yrcqup9VEw6hFRad4S8bYQ1C7jhSSVtfRgcOL7GRRMOy79d25-_Y8qKPnE7jagamYJu0A_miBsK7i7JDm_mbRcNoZQ_ksb0CUnOEP_3HzbJH4QQOQMDqAXdSYZIVxG1EaAm6oFkGDsMfUdD_A2Dp1ST5dXZ1NSdq4DL6Jt5QvLqC5hOazi_1lZCiSBH8s6PlrGJB6ReZm3CRRGLNHbBU5CjoojnXY6bbq90wQjk9Knyyt4awuQoZYbv6n_0WYwo2gXZuQ_odconbJ2KZKnUyqO_dM6uE5cLQ3Tyh7tNfYouwiVt7qaPE7tqhdo6E0skm1aVJyjW7Rz3c6b13oKNtp9Sn64tUxt4jSYZiftvdi0-XIoAg==" while sending to client, client: 127.0.0.1, server: proxy_caching_, request: "GET /v2/cloudrun/container/hello/blobs/sha256:40e20dde00b1c3846cee2f28401d7301fe81e2e2092865ada31760320203ea05 HTTP/1.1", host: "us-docker.pkg.dev"
```

This PR catches the scenario where `Location` does not have an `http/s` pre-fix, and appends the original `scheme` and `$host` uri