### PR TITLE
feat(nginx): increase proxy buffers, add buffer ENV toggle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,6 +106,11 @@ ENV ALLOW_PUSH="false"
 # Default is true to not change default behavior.
 ENV PROXY_REQUEST_BUFFERING="true"
 
+# Stream data; reduce TTFB
+# Effectively disables caching
+# Default is true to not change default behavior.
+ENV PROXY_BUFFERING="true"
+
 # Should we allow overridding with own authentication, default to false.
 ENV ALLOW_OWN_AUTH="false"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -291,6 +291,18 @@ cat /etc/nginx/nginx.timeouts.config.conf
 echo -e "---\n"
 
 # Request buffering
+echo "" > /etc/nginx/proxy.buffering.conf
+if [[ "a${PROXY_BUFFERING}" == "afalse" ]]; then
+  cat << EOD > /etc/nginx/proxy.buffering.conf
+  proxy_buffering off;
+EOD
+fi
+
+echo -e "\nBuffering: ---"
+cat /etc/nginx/proxy.buffering.conf
+echo -e "---\n"
+
+# Request buffering
 echo "" > /etc/nginx/proxy.request.buffering.conf
 if [[ "a${PROXY_REQUEST_BUFFERING}" == "afalse" ]]; then
   cat << EOD > /etc/nginx/proxy.request.buffering.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -11,6 +11,9 @@ events {
 }
 
 http {
+    proxy_buffer_size   128k;
+    proxy_busy_buffers_size   256k;
+    proxy_buffers   4 256k;
     map_hash_bucket_size 128;
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
@@ -227,6 +230,9 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         include "/etc/nginx/conf.d/allowed.methods.conf";
 
         proxy_read_timeout 900;
+
+        # Buffering
+        include /etc/nginx/proxy.buffering.conf;
 
         # Request buffering
         include /etc/nginx/proxy.request.buffering.conf;


### PR DESCRIPTION
Increases proxy buffers for large image sizes

Fixes `upstream sent too big header while reading response header from upstream`

Reference: 

- https://stackoverflow.com/a/27551259
- https://www.getpagespeed.com/server-setup/nginx/tuning-proxy_buffer_size-in-nginx
- http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering