### PR TITLE
feat(liveness): use k8s http liveness rules

### DIFF
--- a/liveliness.sh
+++ b/liveliness.sh
@@ -8,7 +8,7 @@ for i in "${repos[@]}"
 do
   echo "repo $i liveliness check..."
   response=$(curl --head -L -w '%{http_code}' -o /dev/null -s -k -x http://127.0.0.1:3128 "$i")
-  if [ "$response" -ne 200 ]; then
+  if [[ "$response" -lt "200" ]] || [[ "$response" -ge "400" ]]; then
     echo "failed curl for repo $i"
     exit 1
   fi


### PR DESCRIPTION
greater than or equal to 200 but less than 400 is success

ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#define-a-liveness-http-request