### PR TITLE
feat(nginx): tune caching thresholds for large images

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,7 @@ CACHE_MAX_SIZE=${CACHE_MAX_SIZE:-32g}
 
 # The cache directory. This can get huge. Better to use a Docker volume pointing here!
 # Set to 32gb which should be enough
-echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE min_free=${CACHE_MIN_FREE:-0} inactive=${CACHE_INACTIVE_TIME:-60d} keys_zone=cache:10m use_temp_path=off manager_threshold=${CACHE_MANAGER_THRESHOLD:-200ms} manager_sleep=${CACHE_MANAGER_SLEEP:-50ms} manager_files=${CACHE_MANAGER_FILES:-100} loader_files=${CACHE_LOADER_FILES:-100} loader_threshold=${CACHE_LOADER_THRESHOLD:-200ms} loader_sleep=${CACHE_MANAGER_SLEEP:-50ms};" > /etc/nginx/conf.d/cache_max_size.conf
+echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE min_free=${CACHE_MIN_FREE:-0} inactive=${CACHE_INACTIVE_TIME:-60d} keys_zone=cache:10m use_temp_path=off manager_threshold=${CACHE_MANAGER_THRESHOLD:-1000ms} manager_sleep=${CACHE_MANAGER_SLEEP:-50ms} manager_files=${CACHE_MANAGER_FILES:-100} loader_files=${CACHE_LOADER_FILES:-100} loader_threshold=${CACHE_LOADER_THRESHOLD:-200ms} loader_sleep=${CACHE_MANAGER_SLEEP:-50ms};" > /etc/nginx/conf.d/cache_max_size.conf
 
 # Manifest caching configuration. We generate config based on the environment vars.
 echo -n "" >/etc/nginx/nginx.manifest.caching.config.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,7 @@ CACHE_MAX_SIZE=${CACHE_MAX_SIZE:-32g}
 
 # The cache directory. This can get huge. Better to use a Docker volume pointing here!
 # Set to 32gb which should be enough
-echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE min_free=${CACHE_MIN_FREE:-0} inactive=${CACHE_INACTIVE_TIME:-60d} keys_zone=cache:10m use_temp_path=off manager_threshold=${CACHE_MANAGER_THRESHOLD:-1000ms} manager_sleep=${CACHE_MANAGER_SLEEP:-250ms} manager_files=${CACHE_MANAGER_FILES:-100} loader_files=${CACHE_LOADER_FILES:-100} loader_threshold=${CACHE_LOADER_THRESHOLD:-200ms} loader_sleep=${CACHE_MANAGER_SLEEP:-50ms};" > /etc/nginx/conf.d/cache_max_size.conf
+echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE min_free=${CACHE_MIN_FREE:-1g} inactive=${CACHE_INACTIVE_TIME:-60d} keys_zone=cache:10m use_temp_path=off manager_threshold=${CACHE_MANAGER_THRESHOLD:-1000ms} manager_sleep=${CACHE_MANAGER_SLEEP:-250ms} manager_files=${CACHE_MANAGER_FILES:-100} loader_files=${CACHE_LOADER_FILES:-100} loader_threshold=${CACHE_LOADER_THRESHOLD:-200ms} loader_sleep=${CACHE_MANAGER_SLEEP:-50ms};" > /etc/nginx/conf.d/cache_max_size.conf
 
 # Manifest caching configuration. We generate config based on the environment vars.
 echo -n "" >/etc/nginx/nginx.manifest.caching.config.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,7 @@ CACHE_MAX_SIZE=${CACHE_MAX_SIZE:-32g}
 
 # The cache directory. This can get huge. Better to use a Docker volume pointing here!
 # Set to 32gb which should be enough
-echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE min_free=${CACHE_MIN_FREE:-1g} inactive=${CACHE_INACTIVE_TIME:-60d} keys_zone=cache:10m use_temp_path=off manager_threshold=${CACHE_MANAGER_THRESHOLD:-1000ms} manager_sleep=${CACHE_MANAGER_SLEEP:-250ms} manager_files=${CACHE_MANAGER_FILES:-100} loader_files=${CACHE_LOADER_FILES:-100} loader_threshold=${CACHE_LOADER_THRESHOLD:-200ms} loader_sleep=${CACHE_MANAGER_SLEEP:-50ms};" > /etc/nginx/conf.d/cache_max_size.conf
+echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE min_free=${CACHE_MIN_FREE:-1g} inactive=${CACHE_INACTIVE_TIME:-60d} keys_zone=cache:15m use_temp_path=off manager_threshold=${CACHE_MANAGER_THRESHOLD:-1000ms} manager_sleep=${CACHE_MANAGER_SLEEP:-250ms} manager_files=${CACHE_MANAGER_FILES:-100} loader_files=${CACHE_LOADER_FILES:-100} loader_threshold=${CACHE_LOADER_THRESHOLD:-200ms} loader_sleep=${CACHE_MANAGER_SLEEP:-50ms};" > /etc/nginx/conf.d/cache_max_size.conf
 
 # Manifest caching configuration. We generate config based on the environment vars.
 echo -n "" >/etc/nginx/nginx.manifest.caching.config.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,7 @@ CACHE_MAX_SIZE=${CACHE_MAX_SIZE:-32g}
 
 # The cache directory. This can get huge. Better to use a Docker volume pointing here!
 # Set to 32gb which should be enough
-echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE min_free=${CACHE_MIN_FREE:-0} inactive=${CACHE_INACTIVE_TIME:-60d} keys_zone=cache:10m use_temp_path=off manager_threshold=${CACHE_MANAGER_THRESHOLD:-1000ms} manager_sleep=${CACHE_MANAGER_SLEEP:-50ms} manager_files=${CACHE_MANAGER_FILES:-100} loader_files=${CACHE_LOADER_FILES:-100} loader_threshold=${CACHE_LOADER_THRESHOLD:-200ms} loader_sleep=${CACHE_MANAGER_SLEEP:-50ms};" > /etc/nginx/conf.d/cache_max_size.conf
+echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE min_free=${CACHE_MIN_FREE:-0} inactive=${CACHE_INACTIVE_TIME:-60d} keys_zone=cache:10m use_temp_path=off manager_threshold=${CACHE_MANAGER_THRESHOLD:-1000ms} manager_sleep=${CACHE_MANAGER_SLEEP:-250ms} manager_files=${CACHE_MANAGER_FILES:-100} loader_files=${CACHE_LOADER_FILES:-100} loader_threshold=${CACHE_LOADER_THRESHOLD:-200ms} loader_sleep=${CACHE_MANAGER_SLEEP:-50ms};" > /etc/nginx/conf.d/cache_max_size.conf
 
 # Manifest caching configuration. We generate config based on the environment vars.
 echo -n "" >/etc/nginx/nginx.manifest.caching.config.conf

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,7 @@ CACHE_MAX_SIZE=${CACHE_MAX_SIZE:-32g}
 
 # The cache directory. This can get huge. Better to use a Docker volume pointing here!
 # Set to 32gb which should be enough
-echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE inactive=60d keys_zone=cache:10m use_temp_path=off;" > /etc/nginx/conf.d/cache_max_size.conf
+echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE min_free=${CACHE_MIN_FREE:-0} inactive=${CACHE_INACTIVE_TIME:-60d} keys_zone=cache:10m use_temp_path=off manager_threshold=${CACHE_MANAGER_THRESHOLD:-200ms} manager_sleep=${CACHE_MANAGER_SLEEP:-50ms} manager_files=${CACHE_MANAGER_FILES:-100} loader_files=${CACHE_LOADER_FILES:-100} loader_threshold=${CACHE_LOADER_THRESHOLD:-200ms} loader_sleep=${CACHE_MANAGER_SLEEP:-50ms};" > /etc/nginx/conf.d/cache_max_size.conf
 
 # Manifest caching configuration. We generate config based on the environment vars.
 echo -n "" >/etc/nginx/nginx.manifest.caching.config.conf

--- a/nginx.conf
+++ b/nginx.conf
@@ -317,7 +317,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             proxy_cache cache;
             # But we store the result with the cache key of the original request URI
             # so that future clients don't need to follow the redirect too
-            proxy_cache_key $original_uri;
+            proxy_cache_key $original_uri$slice_range;
         }
 
         # by default, dont cache anything.

--- a/nginx.manifest.common.conf
+++ b/nginx.manifest.common.conf
@@ -3,6 +3,9 @@
     add_header X-Docker-Registry-Proxy-Cache-Type "$docker_proxy_request_type";
     proxy_pass https://$targetHost;
     proxy_cache cache;
-    proxy_cache_key   $uri;
+    slice 4m;
+    proxy_cache_key   $uri$slice_range;
+    proxy_set_header   Range $slice_range;
+    proxy_http_version 1.1;
     proxy_intercept_errors on;
     error_page 301 302 307 = @handle_redirects;


### PR DESCRIPTION
Ref:

- http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_path
- https://ahelpme.com/software/nginx/tune-nginx-proxy-cache-control-the-cache-manager-how-to-delete-cached-files/
- https://www.nginx.com/blog/smart-efficient-byte-range-caching-nginx/

Large Docker images can store large blobs that require more time to delete than the default threshold of `200ms`

```
/docker_mirror_cache/f/91:
total 2.7G
-rw------- 1 nginx nginx 2.7G Sep 14 13:17 80261021ef8a0e942bdda9de4913591f

bash-5.0# time $(rm -rf /docker_mirror_cache/f/91)

real    0m0.222s
user    0m0.000s
sys     0m0.220s
```

Extending the deletion threshold (and increasing the sleep time proportionately) should allow for deletion events to work more effectively for larger blobs.

Additionally, this PR enables the [slice module](https://nginx.org/en/docs/http/ngx_http_slice_module.html) per @robbat2 suggestion 

nginx version in this image is [built with](https://github.com/rpardini/nginx-proxy-connect-stable-alpine/blob/46602a4d1f095533d2a5cac528ee2558ce546c68/Dockerfile#L47) the module enabled