### PR TITLE
fix(nginx): Revert "feat(nginx): use slice module"

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -102,7 +102,7 @@ CACHE_MAX_SIZE=${CACHE_MAX_SIZE:-32g}
 
 # The cache directory. This can get huge. Better to use a Docker volume pointing here!
 # Set to 32gb which should be enough
-echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE min_free=${CACHE_MIN_FREE:-1g} inactive=${CACHE_INACTIVE_TIME:-60d} keys_zone=cache:15m use_temp_path=off manager_threshold=${CACHE_MANAGER_THRESHOLD:-1000ms} manager_sleep=${CACHE_MANAGER_SLEEP:-250ms} manager_files=${CACHE_MANAGER_FILES:-100} loader_files=${CACHE_LOADER_FILES:-100} loader_threshold=${CACHE_LOADER_THRESHOLD:-200ms} loader_sleep=${CACHE_MANAGER_SLEEP:-50ms};" > /etc/nginx/conf.d/cache_max_size.conf
+echo "proxy_cache_path /docker_mirror_cache levels=1:2 max_size=$CACHE_MAX_SIZE min_free=${CACHE_MIN_FREE:-1g} inactive=${CACHE_INACTIVE_TIME:-60d} keys_zone=cache:10m use_temp_path=off manager_threshold=${CACHE_MANAGER_THRESHOLD:-1000ms} manager_sleep=${CACHE_MANAGER_SLEEP:-250ms} manager_files=${CACHE_MANAGER_FILES:-100} loader_files=${CACHE_LOADER_FILES:-100} loader_threshold=${CACHE_LOADER_THRESHOLD:-200ms} loader_sleep=${CACHE_MANAGER_SLEEP:-50ms};" > /etc/nginx/conf.d/cache_max_size.conf
 
 # Set Docker Registry cache valid time, by default, 60 day ('60d')
 CACHE_VALID_TIME=${CACHE_VALID_TIME:-60d}

--- a/nginx.conf
+++ b/nginx.conf
@@ -316,7 +316,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             proxy_cache cache;
             # But we store the result with the cache key of the original request URI
             # so that future clients don't need to follow the redirect too
-            proxy_cache_key $original_uri$slice_range;
+            proxy_cache_key $original_uri;
         }
 
         # by default, dont cache anything.

--- a/nginx.manifest.common.conf
+++ b/nginx.manifest.common.conf
@@ -3,9 +3,6 @@
     add_header X-Docker-Registry-Proxy-Cache-Type "$docker_proxy_request_type";
     proxy_pass https://$targetHost;
     proxy_cache cache;
-    slice 4m;
-    proxy_cache_key   $uri$slice_range;
-    proxy_set_header   Range $slice_range;
-    proxy_http_version 1.1;
+    proxy_cache_key   $uri;
     proxy_intercept_errors on;
     error_page 301 302 307 = @handle_redirects;


### PR DESCRIPTION
This reverts commit 9cd01352c3caa569010f085be2010aa04f19c4ca.

Seems to cause a problem with some registries; reverting for now

```
2023-09-26T02:30:22.656467411Z stderr F 2023/09/26 02:30:22 [error] 105#105: *40145 unexpected status code 401 in slice response while reading response header from upstream, client: 127.0.0.1, server: proxy_caching_, request: "GET /v2/falcon-sensor/us-2/release/falcon-sensor/blobs/sha256:d5a0125ef6d485c01d5377d4ebe3d74d89ed703a1be60c20529ff5c73a29cc9f HTTP/1.1", subrequest: "/v2/falcon-sensor/us-2/release/falcon-sensor/blobs/sha256:d5a0125ef6d485c01d5377d4ebe3d74d89ed703a1be60c20529ff5c73a29cc9f", upstream: "https://44.241.67.109:443/v2/falcon-sensor/us-2/release/falcon-sensor/blobs/sha256:d5a0125ef6d485c01d5377d4ebe3d74d89ed703a1be60c20529ff5c73a29cc9f", host: "registry.crowdstrike.com"
```