### PR TITLE
feat(entrypoint): add support for slow caching tier 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,8 @@ ENV DEBUG="false"
 ENV DEBUG_HUB="false"
 # Enable nginx debugging mode; this uses nginx-debug binary and enabled debug logging, which is VERY verbose so separate setting
 ENV DEBUG_NGINX="false"
+# Enable slow caching tier; this allows caching in a secondary cache path on e.g a larger slower disk; for known URIs defined in SLOW_TIER_URIS
+ENV SLOW_TIER_ENABLED="false"
 
 # Manifest caching tiers. Disabled by default, to mimick 0.4/0.5 behaviour.
 # Setting it to true enables the processing of the ENVs below.

--- a/nginx.conf
+++ b/nginx.conf
@@ -316,7 +316,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
 
             # nginx goes to fetch the value from the upstream Location header
             proxy_pass $orig_loc;
-            proxy_cache cache;
+            proxy_cache $cache;
             # But we store the result with the cache key of the original request URI
             # so that future clients don't need to follow the redirect too
             proxy_cache_key $original_uri$slice_range;

--- a/nginx.manifest.common.conf
+++ b/nginx.manifest.common.conf
@@ -2,7 +2,7 @@
     add_header X-Docker-Registry-Proxy-Cache-Upstream-Status "$upstream_cache_status";
     add_header X-Docker-Registry-Proxy-Cache-Type "$docker_proxy_request_type";
     proxy_pass https://$targetHost;
-    proxy_cache cache;
+    proxy_cache $cache;
     slice 4m;
     proxy_cache_key   $uri$slice_range;
     proxy_set_header   Range $slice_range;


### PR DESCRIPTION
Allow caching of specified targets to a separate caching location

URIs are provided in nginx regex location format and semi-colon separate in env var e.g `SLOW_TIER_URIS="~^/v2/coreweave/(.*);~^/v2/nvidia/(.+)"`
