### PR TITLE
Bump nginx, fix upstreams with selective WWW-Authentication responses 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ ARG DO_DEBUG_BUILD="${DEBUG_IMAGE:-"0"}"
 # Build mitmproxy via pip. This is heavy, takes minutes do build and creates a 90mb+ layer. Oh well.
 RUN [[ "a$DO_DEBUG_BUILD" == "a1" ]] && { echo "Debug build ENABLED." \
  && apk add --no-cache --update su-exec cargo bsd-compat-headers git g++ libffi libffi-dev libstdc++ openssl-dev python3 python3-dev py3-pip py3-wheel py3-six py3-idna py3-certifi py3-setuptools \
+ && sed -i 's|v3\.\d*|edge|' /etc/apk/repositories \
+ && apk --no-cache upgrade rust \
  && rm /usr/lib/python3.*/EXTERNALLY-MANAGED \
  && LDFLAGS=-L/lib pip install MarkupSafe mitmproxy \
  && apk del --purge git g++ libffi-dev openssl-dev python3-dev py3-pip py3-wheel \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # We start from my nginx fork which includes the proxy-connect module from tEngine
 # Source is available at https://github.com/rpardini/nginx-proxy-connect-stable-alpine
 # This is already multi-arch!
-ARG BASE_IMAGE="registry.gitlab.com/coreweave/nginx-proxy-connect-stable-alpine:v1.0.1"
+ARG BASE_IMAGE="registry.gitlab.com/coreweave/nginx-proxy-connect-stable-alpine:v1.2.0"
 ARG DEBUG_IMAGE
 # Could be "-debug"
 

--- a/nginx.conf
+++ b/nginx.conf
@@ -332,10 +332,18 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             add_header X-Docker-Registry-Proxy-Cache-Key-Status "$cache_key$slice_range";
         }
 
+        # Don't send Authorization to /v2/ to trigger WWW-Authenticate; don't cache these
+        location /v2/ {
+            proxy_pass https://$targetHost;
+            proxy_set_header      Authorization "";
+            proxy_cache off;
+        }
+
         # by default, dont cache anything.
         location / {
             proxy_pass https://$targetHost;
             proxy_cache off;
         }
+
     }
 }


### PR DESCRIPTION
- Bumps [nginx](https://github.com/coreweave/nginx-proxy-connect-stable-alpine/pull/4) and [alpine](https://github.com/coreweave/nginx-proxy-connect-stable-alpine/pull/5) deps 
- Temporarily sources rust from edge - this can be reverted once Rust 1.80 makes it to a non-edge branch
- Fixes upstreams that don't always send `WWW-Authentication`:

Some upstreams won't set the `WWW-Authentication` header on response if you send the `Authorization` header in the `GET` against `/v2/`. We expect this header to re-direct us to `/login` or `/jwt` where we can a `Bearer` token response. Without this, authentication will fail, since it never happens at the right place. 