### PR TITLE
fix(config): strict modifier on v2 location block

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -333,7 +333,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         }
 
         # Don't send Authorization to /v2/ to trigger WWW-Authenticate; don't cache these
-        location /v2/ {
+        location = /v2/ {
             proxy_pass https://$targetHost;
             proxy_set_header      Authorization "";
             proxy_cache off;


### PR DESCRIPTION
without the strict modifier, it will match against the beginning of any uri