### PR TITLE
Revert "feat(nginx): use slice module"

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -328,8 +328,8 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             proxy_cache $cache;
             # But we store the result with the cache key of the original request URI
             # so that future clients don't need to follow the redirect too
-            proxy_cache_key $cache_key$slice_range;
-            add_header X-Docker-Registry-Proxy-Cache-Key-Status "$cache_key$slice_range";
+            proxy_cache_key $cache_key;
+            add_header X-Docker-Registry-Proxy-Cache-Key-Status "$cache_key";
         }
 
         # Don't send Authorization to /v2/ to trigger WWW-Authenticate; don't cache these

--- a/nginx.manifest.common.conf
+++ b/nginx.manifest.common.conf
@@ -3,10 +3,8 @@
     add_header X-Docker-Registry-Proxy-Cache-Type "$docker_proxy_request_type";
     proxy_pass https://$targetHost;
     proxy_cache $cache;
-    slice 4m;
-    proxy_cache_key   $cache_key$slice_range;
-    proxy_set_header   Range $slice_range;
-    add_header X-Docker-Registry-Proxy-Cache-Key-Status "$cache_key$slice_range";
+    proxy_cache_key   $cache_key;
+    add_header X-Docker-Registry-Proxy-Cache-Key-Status "$cache_key";
     proxy_http_version 1.1;
     proxy_intercept_errors on;
     error_page 301 302 307 = @handle_redirects;


### PR DESCRIPTION
This reverts commit 9cd01352c3caa569010f085be2010aa04f19c4ca.

This seems to cause more problems than it solves - 

```
< X-Docker-Registry-Proxy-Cache-Upstream-Status: HIT
< X-Docker-Registry-Proxy-Cache-Type: manifest-secondary
< Accept-Ranges: bytes
< 
* transfer closed with 1609 bytes remaining to read
* Closing connection 0
* TLSv1.3 (OUT), TLS alert, close notify (256):
curl: (18) transfer closed with 1609 bytes remaining to read
```

Since cache key is defined in common, slice module applies to manifests as well, which seems to lead to `unexpected EOF` pulling image manifests on occasion 