### PR TITLE
fix(config): extend cache lock age

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -244,6 +244,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
         # will wait for the first to finish instead of doing multiple upstream requests.
         proxy_cache_lock on;
         proxy_cache_lock_timeout 880s;
+        proxy_cache_lock_age 880s;
 
         # Cache all 200, 206 for 60 days default.
 


### PR DESCRIPTION
By default these values are set the same - an extended timeout will not help much if the subsequent request is allowed through in a shorter timeframe

https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_cache_lock_age