### PR TITLE
feat(conf): add bitnami host and uri override

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ ARG DO_DEBUG_BUILD="${DEBUG_IMAGE:-"0"}"
 # Build mitmproxy via pip. This is heavy, takes minutes do build and creates a 90mb+ layer. Oh well.
 RUN [[ "a$DO_DEBUG_BUILD" == "a1" ]] && { echo "Debug build ENABLED." \
  && apk add --no-cache --update su-exec cargo bsd-compat-headers git g++ libffi libffi-dev libstdc++ openssl-dev python3 python3-dev py3-pip py3-wheel py3-six py3-idna py3-certifi py3-setuptools \
- && sed -i 's|v3\.\d*|edge|' /etc/apk/repositories \
- && apk --no-cache upgrade rust \
  && rm /usr/lib/python3.*/EXTERNALLY-MANAGED \
  && LDFLAGS=-L/lib pip install MarkupSafe mitmproxy \
  && apk del --purge git g++ libffi-dev openssl-dev python3-dev py3-pip py3-wheel \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # We start from my nginx fork which includes the proxy-connect module from tEngine
 # Source is available at https://github.com/rpardini/nginx-proxy-connect-stable-alpine
 # This is already multi-arch!
-ARG BASE_IMAGE="registry.gitlab.com/coreweave/nginx-proxy-connect-stable-alpine:v1.2.0"
+ARG BASE_IMAGE="registry.gitlab.com/coreweave/nginx-proxy-connect-stable-alpine:v1.5.0"
 ARG DEBUG_IMAGE
 # Could be "-debug"
 
@@ -12,7 +12,7 @@ ARG BASE_IMAGE_SUFFIX="${IMAGE_SUFFIX}"
 FROM ${BASE_IMAGE}${BASE_IMAGE_SUFFIX}
 
 # Link image to original repository on GitHub
-LABEL org.opencontainers.image.source=https://github.com/rpardini/docker-registry-proxy
+LABEL org.opencontainers.image.source=https://github.com/coreweave/docker-registry-proxy
 
 # apk packages that will be present in the final image both debug and release
 RUN apk add --no-cache --update bash ca-certificates-bundle coreutils openssl
@@ -23,9 +23,8 @@ ARG DO_DEBUG_BUILD="${DEBUG_IMAGE:-"0"}"
 
 # Build mitmproxy via pip. This is heavy, takes minutes do build and creates a 90mb+ layer. Oh well.
 RUN [[ "a$DO_DEBUG_BUILD" == "a1" ]] && { echo "Debug build ENABLED." \
- && apk add --no-cache --update su-exec cargo bsd-compat-headers git g++ libffi libffi-dev libstdc++ openssl-dev python3 python3-dev py3-pip py3-wheel py3-six py3-idna py3-certifi py3-setuptools \
+ && apk add --no-cache --update su-exec cargo bsd-compat-headers git g++ libffi libffi-dev libstdc++ openssl-dev python3 python3-dev py3-pip py3-wheel py3-six py3-idna py3-certifi py3-setuptools mitmproxy \
  && rm /usr/lib/python3.*/EXTERNALLY-MANAGED \
- && LDFLAGS=-L/lib pip install MarkupSafe mitmproxy \
  && apk del --purge git g++ libffi-dev openssl-dev python3-dev py3-pip py3-wheel \
  && rm -rf ~/.cache/pip \
  ; } || { echo "Debug build disabled." ; }

--- a/Dockerfile
+++ b/Dockerfile
@@ -146,8 +146,13 @@ ENV PROXY_CONNECT_READ_TIMEOUT="60s"
 ENV PROXY_CONNECT_CONNECT_TIMEOUT="60s"
 ENV PROXY_CONNECT_SEND_TIMEOUT="60s"
 
-# Allow disabling IPV6 resolution, default to false
-ENV DISABLE_IPV6="false"
+# Allow disabling IPV6 resolution, default to true
+ENV DISABLE_IPV6="true"
+
+# Bitnami dockerhub overrides
+ENV BITNAMI_DOCKERHUB_HOST_OVERRIDE="false"
+ENV BITNAMI_HOST=""
+ENV BITNAMI_LEGACY_DOCKERHUB_URI_REWRITE="false"
 
 # Did you want a shell? Sorry, the entrypoint never returns, because it runs nginx itself. Use 'docker exec' if you need to mess around internally.
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -50,7 +50,7 @@ ALLDOMAINS=""
 echo -n "" > /etc/nginx/docker.intercept.map
 
 # Some hosts/registries are always needed, but others can be configured in env var REGISTRIES
-for ONEREGISTRYIN in docker.caching.proxy.internal registry-1.docker.io auth.docker.io ${REGISTRIES}; do
+for ONEREGISTRYIN in docker.caching.proxy.internal index.docker.io registry-1.docker.io auth.docker.io ${REGISTRIES}; do
     ONEREGISTRY=$(echo ${ONEREGISTRYIN} | xargs) # Remove whitespace
     echo "Adding certificate for registry: $ONEREGISTRY"
     ALLDOMAINS="${ALLDOMAINS},DNS:${ONEREGISTRY}"
@@ -398,6 +398,37 @@ fi
 
 # Set worker processes if provided
 sed -i "s/worker_processes  auto;/worker_processes  ${WORKER_PROCESSES};/g" /etc/nginx/nginx.conf
+
+echo "" > /etc/nginx/nginx.manifest.override.conf
+if [[ "a${BITNAMI_DOCKERHUB_HOST_OVERRIDE}" == "atrue" && ${BITNAMI_HOST} != "" ]]; then
+    cat << EOD >> /etc/nginx/nginx.manifest.override.conf
+    set \$overrideHost 0;
+    if (\$request_uri ~ ^/v2/bitnami/) {
+        set \$overrideHost 1;
+    }
+    if (\$host !~* (^|\.)docker\.io$) {
+        set \$overrideHost 0;
+    }
+    if (\$overrideHost) {
+        set \$targetHost "${BITNAMI_HOST}";
+    }
+EOD
+fi
+
+if [[ "a${BITNAMI_LEGACY_DOCKERHUB_URI_REWRITE}" == "atrue" ]]; then
+    cat << EOD >> /etc/nginx/nginx.manifest.override.conf
+    set \$doRewrite 0;
+    if (\$request_uri ~ ^/v2/bitnami/) {
+        set \$doRewrite 1;
+    }
+    if (\$host !~* (^|\.)docker\.io$) {
+        set \$doRewrite 0;
+    }
+    if (\$doRewrite) {
+        rewrite ^/v2/bitnami/(.*)$ /v2/bitnamilegacy\$1 break;
+    }
+EOD
+fi
 
 echo -e "\nFinal resolver configuration: ---"
 cat "${confpath}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ echo "DEBUG, determined RESOLVERS from /etc/resolv.conf: '$RESOLVERS'"
 conf=""
 for ONE_RESOLVER in ${RESOLVERS}; do
 	echo "Possible resolver: $ONE_RESOLVER"
-	conf="resolver $ONE_RESOLVER ipv6=off; "
+	conf="resolver $ONE_RESOLVER; "
 done
 
 echo "Final chosen resolver: $conf"

--- a/nginx.conf
+++ b/nginx.conf
@@ -81,7 +81,11 @@ http {
         '"upstream_response_time":"$upstream_response_time",'
         '"host":"$host",'
         '"proxy_host":"$proxy_host",'
-        '"upstream":"$upstream_addr"'
+        '"upstream":"$upstream_addr",'
+        '"user_agent":"$http_user_agent",'
+        '"remote_addr":"$remote_addr",'
+        '"upstream_bytes_received":"$upstream_response_length",'
+        '"upstream_response_time":"$upstream_response_time"'
       '}';
 
     gzip  off;

--- a/nginx.manifest.common.conf
+++ b/nginx.manifest.common.conf
@@ -1,4 +1,5 @@
     # nginx config fragment included in every manifest-related location{} block.
+    include "/etc/nginx/nginx.manifest.override.conf";
     add_header X-Docker-Registry-Proxy-Cache-Upstream-Status "$upstream_cache_status";
     add_header X-Docker-Registry-Proxy-Cache-Type "$docker_proxy_request_type";
     proxy_pass https://$targetHost;


### PR DESCRIPTION
Adds 

- `BITNAMI_DOCKERHUB_HOST_OVERRIDE`
  - Overrides pulls from Bitnami dockerhub to a separate (likely mirror) host
- `BITNAMI_HOST`
  - New host for above option
- `BITNAMI_LEGACY_DOCKERHUB_URI_REWRITE`
  - url rewrites repo `bitnami` to `bitnamilegacy`

